### PR TITLE
Adjusted GCE run script for gVINC

### DIFF
--- a/run_gce_c2s60.sh
+++ b/run_gce_c2s60.sh
@@ -24,10 +24,9 @@ source ~/.bashrc
 #    This particular model needs 2 x 16 x 6 = 4 x 8 x 6 = 192 threads.
 #    In the two cases above, 16x6 means 2 quantity 96CPU instances and
 #                             8x6 means 4 quantity 48CPU instances.
-# 2. We do not need to module load libfabric-aws since the node
-#    is able to run fi_info by default.
+# 2. We do not need to module load libfabric-aws or any EFA env vars
+#    since this is on GCE.  GCE gvnic env vars are autoconfigured.
 # 3. Change the output logging from %j to %J.%t
-# 4. Remove #SBATCH --exclusive to sidestep current login issues.
 cd $HOME/conus_12km/
 cat > slurm-wrf-conus12km.sh <<EOF
 #!/bin/bash
@@ -38,22 +37,17 @@ cat > slurm-wrf-conus12km.sh <<EOF
 #SBATCH --ntasks-per-node=4
 #SBATCH --exclusive
 
-export I_MPI_OFI_LIBRARY_INTERNAL=0
 spack load intel-oneapi-mpi
 spack load wrf
-#module load libfabric-aws
 wrf_exe=$(spack location -i wrf)/run/wrf.exe
 set -x
 ulimit -s unlimited
 ulimit -a
 
 export OMP_NUM_THREADS=6
-export FI_PROVIDER=efa
-export I_MPI_FABRICS=ofi
-export I_MPI_OFI_PROVIDER=efa
 export I_MPI_PIN_DOMAIN=omp
 export KMP_AFFINITY=compact
-export I_MPI_DEBUG=4
+export I_MPI_DEBUG=6
 
 time mpiexec.hydra -np \$SLURM_NTASKS --ppn \$SLURM_NTASKS_PER_NODE \$wrf_exe
 EOF
@@ -62,4 +56,4 @@ EOF
 sbatch slurm-wrf-conus12km.sh
 
 # Clean up
-rm -f slurm-wrf-conus12km.sh
+#rm -f slurm-wrf-conus12km.sh


### PR DESCRIPTION
PW clusters are set up to autoconfigure whichever cloud's
network fabric is present (e.g. AWS' EFA, Google's gVINC,
Azure's Infiniband). Previous versions of the GCE run script
were based on an AWS example that explicitly uses EFA -> those
EFA settings were breaking the connection to gVINC autoconfigured
in the background during provisioning. By simply removing the
explicit config lines, the script works. The next step is to
test using a general Spack archive, head node image builder, and
launch script so that the same scripts work across all three clouds.
This will show that the clusters are very general.